### PR TITLE
fixed json encoding

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -321,7 +321,7 @@ class Core
      */
     public static function url(string $url): string
     {
-        $domain_name = config('transfer.sandbox', true)
+        $domain_name = config('slickpay.sandbox', true)
             ? "devapi.slick-pay.com"
             : "prodapi.slick-pay.com";
 


### PR DESCRIPTION
The library was not encoding json data before sending it to the server and i was always getting this validation errors when creating an invoice 

```
{
    "data": null,
    "status": 422,
    "errors": {
        "webhook_meta_data": [
            "Le champ webhook meta data doit \u00eatre un tableau."
        ],
        "items": [
            "Le champ items doit \u00eatre un tableau."
        ]
    }
}
```

Here is an example of the payload i was using 

```
$data = [
        'amount' => (float)$bill->total_amount,
        'url' => config('slickpay.client_return_url'),
        'qrcode' => false,
        'firstname' => $bill->user->first_name,
        'lastname' => $bill->user->last_name,
        'phone' => $bill->user->phone,
        'email' => $bill->user->email,
        'address' => $bill->user->address ?? '',
        'webhook_url' => config('slickpay.webhook.url'),
        'webhook_signature' => config('slickpay.webhook.secret'),
        'webhook_meta_data' => [
            'bill_id' => $bill->id,
            'commission' => $commission,
        ],
        'note' => 'Payment for Photo Paper Printing Service',
        'items' => [[
            'name' => 'Photo Paper Printing Service',
            'price' => (float)$bill->total_amount,
            'quantity' => 1,
        ]],
    ];
```

I had to encode the data to json and pass the header Content-Type : application/json to make it work